### PR TITLE
add cache directives

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -47,6 +47,11 @@ squid3_http_access:
   - { perm: 'deny', aclname: 'all' }
   ### default ###
 
+squid3_cache_directives:
+  ### default ###
+  - { perm: 'allow', aclname: 'all' }
+  ### default ###
+
 squid3_refresh_pattern:
   ### default ###
   - { case_sensitive: '', regex: '^ftp:', min: '1440', percent: '20%', max: '10080', opts: '' }

--- a/templates/squid.conf.j2
+++ b/templates/squid.conf.j2
@@ -48,6 +48,12 @@ http_access {{ http_access.perm }} {{ http_access.aclname }}
 http_access {{ http_access.perm }} {{ http_access.aclname }}
 {% endfor %}
 
+{% if squid3_cache_directives is defined %}
+{% for cache_directive in squid3_cache_directives %}
+cache {{ cache_directive.perm }} {{ cache_directive.aclname }}
+{% endfor %}
+{% endif %}
+
 http_port {{ squid3_port }}
 
 {% if squid3_diskcache %}


### PR DESCRIPTION
Add  squid3_cache_directives to defaults/main.yml and use it in templates/squid.conf.j2. The default behavior allows the aclname 'all' to cache, but having this present allows it to be overridden, as many simply want to use squid3 as a proxy without caching, needing the 'cache deny all' entry to be present in the configuration.
