### PR TITLE
add forwarded_for option

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -52,6 +52,8 @@ squid3_cache_directives:
   - { perm: 'allow', aclname: 'all' }
   ### default ###
 
+squid3_forwarded_for: 'on'
+
 squid3_refresh_pattern:
   ### default ###
   - { case_sensitive: '', regex: '^ftp:', min: '1440', percent: '20%', max: '10080', opts: '' }

--- a/templates/squid.conf.j2
+++ b/templates/squid.conf.j2
@@ -54,6 +54,10 @@ cache {{ cache_directive.perm }} {{ cache_directive.aclname }}
 {% endfor %}
 {% endif %}
 
+{% if squid3_forwarded_for %}
+forwarded_for {{ squid3_forwarded_for }}
+{% endif %}
+
 http_port {{ squid3_port }}
 
 {% if squid3_diskcache %}


### PR DESCRIPTION
Add the forwarded_for option, so as to allow configuration of how we want X-Forwarded-For to behave. Defaulting to 'on' which is also in line with the squid3 default. See http://www.squid-cache.org/Doc/config/forwarded_for/
